### PR TITLE
Move some functions on app down to individual pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -142,18 +142,9 @@ class App extends React.Component {
 
     updatePose = pose => this.updatePlot(this.state.hexapod.dimensions, pose)
 
-    updatePatternPose = (name, value) => {
-        const { pose, dimensions } = this.state.hexapod
-        let newPose = {}
-
-        for (const leg in pose) {
-            newPose[leg] = { ...pose[leg], [name]: Number(value) }
-        }
-
-        this.setState({
-            patternParams: { ...this.state.patternParams, [name]: value },
-        })
-        this.updatePlot(dimensions, newPose)
+    updatePatternPose = (pose, patternParams) => {
+        this.updatePlot(this.state.hexapod.dimensions, pose)
+        this.setState({ patternParams })
     }
 
     /* * * * * * * * * * * * * *

--- a/src/App.js
+++ b/src/App.js
@@ -140,14 +140,7 @@ class App extends React.Component {
         this.setState({ ikParams: newIkParams })
     }
 
-    updatePose = (name, angle, value) => {
-        const { pose, dimensions } = this.state.hexapod
-        const newPose = {
-            ...pose,
-            [name]: { ...pose[name], [angle]: value },
-        }
-        this.updatePlot(dimensions, newPose)
-    }
+    updatePose = pose => this.updatePlot(this.state.hexapod.dimensions, pose)
 
     updatePatternPose = (name, value) => {
         const { pose, dimensions } = this.state.hexapod

--- a/src/App.js
+++ b/src/App.js
@@ -140,7 +140,6 @@ class App extends React.Component {
             <DimensionsWidget
                 dimensions={this.state.hexapod.dimensions}
                 onUpdate={this.updateDimensions}
-                onReset={this.reset}
             />
         ) : null
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom"
-import { VirtualHexapod, getNewPlotParams, solveInverseKinematics } from "./hexapod"
+import { VirtualHexapod, getNewPlotParams } from "./hexapod"
 import {
     DEFAULT_DIMENSIONS,
     DEFAULT_POSE,
@@ -105,28 +105,11 @@ class App extends React.Component {
      * Handle individual input fields update
      * * * * * * * * * * * * * */
 
-    updateIkParams = (name, value) => {
-        const newIkParams = { ...this.state.ikParams, [name]: value }
-
-        const { dimensions } = this.state.hexapod
-        const result = solveInverseKinematics(dimensions, newIkParams)
-
-        if (result.obtainedSolution) {
-            this.updatePlotWithHexapod(result.hexapod)
-            this.setState({
-                showPoseMessage: true,
-                showInfo: false,
-                info: { ...result.message, isAlert: false },
-            })
-        } else {
-            this.setState({
-                showPoseMessage: false,
-                showInfo: true,
-                info: { ...result.message, isAlert: true },
-            })
+    updateIkParams = (hexapod, updatedStateParams) => {
+        if (hexapod !== null) {
+            this.updatePlotWithHexapod(hexapod)
         }
-
-        this.setState({ ikParams: newIkParams })
+        this.setState({ ...updatedStateParams })
     }
 
     updateDimensions = dimensions => this.updatePlot(dimensions, this.state.hexapod.pose)
@@ -147,10 +130,6 @@ class App extends React.Component {
     mightShowDetailedNav = () => (this.state.inHexapodPage ? <NavDetailed /> : null)
 
     mightShowPoseTable = () => {
-        if (this.state.currentPage !== "Inverse Kinematics") {
-            return null
-        }
-
         if (this.state.showPoseMessage) {
             return <PoseTable pose={this.state.hexapod.pose} />
         }
@@ -190,7 +169,10 @@ class App extends React.Component {
             </Route>
             <Route path="/inverse-kinematics">
                 <InverseKinematicsPage
-                    params={this.state.ikParams}
+                    params={{
+                        dimensions: this.state.hexapod.dimensions,
+                        ikParams: this.state.ikParams,
+                    }}
                     onUpdate={this.updateIkParams}
                     onMount={this.onPageLoad}
                 />

--- a/src/App.js
+++ b/src/App.js
@@ -27,18 +27,21 @@ import {
 
 class App extends React.Component {
     state = {
+
         currentPage: "Root",
         inHexapodPage: false,
         showPoseMessage: true,
         showInfo: false,
         info: {},
+
         ikParams: DEFAULT_IK_PARAMS,
         patternParams: { alpha: 0, beta: 0, gamma: 0 },
-        hexapod: {
+
+        hexapodParams: {
             dimensions: DEFAULT_DIMENSIONS,
             pose: DEFAULT_POSE,
-            points: {},
         },
+
         plot: {
             data: DATA,
             layout: LAYOUT,
@@ -63,10 +66,10 @@ class App extends React.Component {
             inHexapodPage: true,
             currentPage: pageName,
             ikParams: DEFAULT_IK_PARAMS,
-            hexapod: { ...this.state.hexapod, pose: DEFAULT_POSE },
+            hexapodParams: { ...this.state.hexapodParams, pose: DEFAULT_POSE },
             patternParams: { alpha: 0, beta: 0, gamma: 0 },
         })
-        this.updatePlot(this.state.hexapod.dimensions, DEFAULT_POSE)
+        this.updatePlot(this.state.hexapodParams.dimensions, DEFAULT_POSE)
     }
 
     /* * * * * * * * * * * * * *
@@ -87,8 +90,7 @@ class App extends React.Component {
                 layout,
                 revisionCounter: this.state.plot.revisionCounter + 1,
             },
-            hexapod: {
-                ...this.state.hexapod,
+            hexapodParams: {
                 dimensions: hexapod.dimensions,
                 pose: hexapod.pose,
             },
@@ -112,12 +114,13 @@ class App extends React.Component {
         this.setState({ ...updatedStateParams })
     }
 
-    updateDimensions = dimensions => this.updatePlot(dimensions, this.state.hexapod.pose)
+    updateDimensions = dimensions =>
+        this.updatePlot(dimensions, this.state.hexapodParams.pose)
 
-    updatePose = pose => this.updatePlot(this.state.hexapod.dimensions, pose)
+    updatePose = pose => this.updatePlot(this.state.hexapodParams.dimensions, pose)
 
     updatePatternPose = (pose, patternParams) => {
-        this.updatePlot(this.state.hexapod.dimensions, pose)
+        this.updatePlot(this.state.hexapodParams.dimensions, pose)
         this.setState({ patternParams })
     }
 
@@ -131,14 +134,14 @@ class App extends React.Component {
 
     mightShowPoseTable = () => {
         if (this.state.showPoseMessage) {
-            return <PoseTable pose={this.state.hexapod.pose} />
+            return <PoseTable pose={this.state.hexapodParams.pose} />
         }
     }
 
     mightShowDimensions = () =>
         this.state.inHexapodPage ? (
             <DimensionsWidget
-                dimensions={this.state.hexapod.dimensions}
+                dimensions={this.state.hexapodParams.dimensions}
                 onUpdate={this.updateDimensions}
             />
         ) : null
@@ -161,7 +164,7 @@ class App extends React.Component {
             </Route>
             <Route path="/forward-kinematics">
                 <ForwardKinematicsPage
-                    params={this.state.hexapod.pose}
+                    params={this.state.hexapodParams.pose}
                     onUpdate={this.updatePose}
                     onMount={this.onPageLoad}
                 />
@@ -169,7 +172,7 @@ class App extends React.Component {
             <Route path="/inverse-kinematics">
                 <InverseKinematicsPage
                     params={{
-                        dimensions: this.state.hexapod.dimensions,
+                        dimensions: this.state.hexapodParams.dimensions,
                         ikParams: this.state.ikParams,
                     }}
                     onUpdate={this.updateIkParams}

--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,6 @@ import {
 
 class App extends React.Component {
     state = {
-
         currentPage: "Root",
         inHexapodPage: false,
         showPoseMessage: true,
@@ -141,7 +140,7 @@ class App extends React.Component {
     mightShowDimensions = () =>
         this.state.inHexapodPage ? (
             <DimensionsWidget
-                dimensions={this.state.hexapodParams.dimensions}
+                params={{ dimensions: this.state.hexapodParams.dimensions }}
                 onUpdate={this.updateDimensions}
             />
         ) : null
@@ -164,7 +163,7 @@ class App extends React.Component {
             </Route>
             <Route path="/forward-kinematics">
                 <ForwardKinematicsPage
-                    params={this.state.hexapodParams.pose}
+                    params={{ pose: this.state.hexapodParams.pose }}
                     onUpdate={this.updatePose}
                     onMount={this.onPageLoad}
                 />
@@ -181,7 +180,7 @@ class App extends React.Component {
             </Route>
             <Route path="/leg-patterns">
                 <LegPatternPage
-                    params={this.state.patternParams}
+                    params={{ patternPose: this.state.patternParams }}
                     onUpdate={this.updatePatternPose}
                     onMount={this.onPageLoad}
                 />

--- a/src/App.js
+++ b/src/App.js
@@ -69,12 +69,6 @@ class App extends React.Component {
         this.updatePlot(this.state.hexapod.dimensions, DEFAULT_POSE)
     }
 
-    reset = name => {
-        if (name === "Dimensions") {
-            this.updatePlot(DEFAULT_DIMENSIONS, this.state.hexapod.pose)
-        }
-    }
-
     /* * * * * * * * * * * * * *
      * Handle plot update
      * * * * * * * * * * * * * */
@@ -111,11 +105,6 @@ class App extends React.Component {
      * Handle individual input fields update
      * * * * * * * * * * * * * */
 
-    updateDimensions = (name, value) => {
-        const dimensions = { ...this.state.hexapod.dimensions, [name]: value }
-        this.updatePlot(dimensions, this.state.hexapod.pose)
-    }
-
     updateIkParams = (name, value) => {
         const newIkParams = { ...this.state.ikParams, [name]: value }
 
@@ -139,6 +128,8 @@ class App extends React.Component {
 
         this.setState({ ikParams: newIkParams })
     }
+
+    updateDimensions = dimensions => this.updatePlot(dimensions, this.state.hexapod.pose)
 
     updatePose = pose => this.updatePlot(this.state.hexapod.dimensions, pose)
 

--- a/src/components/DimensionsWidget.js
+++ b/src/components/DimensionsWidget.js
@@ -1,8 +1,9 @@
 import React, { Component } from "react"
 import InputField from "./generic/InputField"
 import { Card } from "./generic/SmallWidgets"
+import { DEFAULT_DIMENSIONS } from "../templates"
 
-const ResetButton = ({reset, children }) => (
+const ResetButton = ({ reset, children }) => (
     <button type="button" class="button" onClick={reset}>
         {children}
     </button>
@@ -12,7 +13,13 @@ class DimensionsWidget extends Component {
     resetLabel = "Reset"
 
     reset = () => {
-        this.props.onReset("Dimensions")
+        const dimensions = { DEFAULT_DIMENSIONS }
+        this.props.onUpdate(dimensions)
+    }
+
+    updateDimensions = (name, value) => {
+        const dimensions = { ...this.props.dimensions, [name]: value }
+        this.props.onUpdate(dimensions)
     }
 
     updateFieldState = (name, value) => {

--- a/src/components/DimensionsWidget.js
+++ b/src/components/DimensionsWidget.js
@@ -18,7 +18,7 @@ class DimensionsWidget extends Component {
     }
 
     updateDimensions = (name, value) => {
-        const dimensions = { ...this.props.dimensions, [name]: value }
+        const dimensions = { ...this.props.params.dimensions, [name]: value }
         this.props.onUpdate(dimensions)
     }
 
@@ -27,12 +27,12 @@ class DimensionsWidget extends Component {
     }
 
     inputFields = () =>
-        Object.keys(this.props.dimensions).map(name => (
+        Object.keys(this.props.params.dimensions).map(name => (
             <InputField
                 key={name}
                 name={name}
                 params={[0, Infinity, 1]}
-                value={this.props.dimensions[name]}
+                value={this.props.params.dimensions[name]}
                 handleChange={this.updateFieldState}
             />
         ))

--- a/src/components/pages/ForwardKinematicsPage.js
+++ b/src/components/pages/ForwardKinematicsPage.js
@@ -29,7 +29,7 @@ class ForwardKinematicsPage extends Component {
     state = { modeBool: false, widgetType: "InputField" }
 
     updatePose = (name, angle, value) => {
-        const pose = this.props.params
+        const pose = this.props.params.pose
         const newPose = {
             ...pose,
             [name]: { ...pose[name], [angle]: value },
@@ -53,7 +53,7 @@ class ForwardKinematicsPage extends Component {
         <LegPoseWidget
             key={name}
             name={name}
-            pose={this.props.params[name]}
+            pose={this.props.params.pose[name]}
             onUpdate={this.updatePose}
             WidgetType={this.widgetTypes[this.state.widgetType]}
             renderStacked={this.state.modeBool}

--- a/src/components/pages/ForwardKinematicsPage.js
+++ b/src/components/pages/ForwardKinematicsPage.js
@@ -28,6 +28,15 @@ class ForwardKinematicsPage extends Component {
 
     state = { modeBool: false, widgetType: "InputField" }
 
+    updatePose = (name, angle, value) => {
+        const pose = this.props.params
+        const newPose = {
+            ...pose,
+            [name]: { ...pose[name], [angle]: value },
+        }
+        this.props.onUpdate(newPose)
+    }
+
     componentDidMount() {
         this.props.onMount(this.pageName)
     }
@@ -45,7 +54,7 @@ class ForwardKinematicsPage extends Component {
             key={name}
             name={name}
             pose={this.props.params[name]}
-            onUpdate={this.props.onUpdate}
+            onUpdate={this.updatePose}
             WidgetType={this.widgetTypes[this.state.widgetType]}
             renderStacked={this.state.modeBool}
         />

--- a/src/components/pages/LegPatternPage.js
+++ b/src/components/pages/LegPatternPage.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import { sliderList, Card } from "../generic"
+import { DEFAULT_POSE } from "../templates"
 
 class LegPatternPage extends Component {
     pageName = "Leg Patterns"
@@ -8,8 +9,22 @@ class LegPatternPage extends Component {
         this.props.onMount(this.pageName)
     }
 
+    updatePatternPose = (name, value) => {
+        let newPose = {}
+
+        for (const leg in DEFAULT_POSE) {
+            newPose[leg] = { ...DEFAULT_POSE[leg], [name]: Number(value) }
+        }
+
+        const patternParams = { ...this.props.params, [name]: value }
+        this.props.onUpdate(newPose, patternParams)
+    }
+
     rotateSliders = () =>
-        sliderList(["alpha", "beta", "gamma"], [-180, 180, 1], this.props)
+        sliderList(["alpha", "beta", "gamma"], [-180, 180, 1], {
+            onUpdate: this.updatePatternPose,
+            params: this.props.params,
+        })
 
     render = () => (
         <Card title={this.pageName} h="h2">

--- a/src/components/pages/LegPatternPage.js
+++ b/src/components/pages/LegPatternPage.js
@@ -16,14 +16,14 @@ class LegPatternPage extends Component {
             newPose[leg] = { ...DEFAULT_POSE[leg], [name]: Number(value) }
         }
 
-        const patternParams = { ...this.props.params, [name]: value }
+        const patternParams = { ...this.props.params.patternParams, [name]: value }
         this.props.onUpdate(newPose, patternParams)
     }
 
     rotateSliders = () =>
         sliderList(["alpha", "beta", "gamma"], [-180, 180, 1], {
             onUpdate: this.updatePatternPose,
-            params: this.props.params,
+            params: this.props.params.patternParams,
         })
 
     render = () => (

--- a/src/components/pages/LegPatternPage.js
+++ b/src/components/pages/LegPatternPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react"
 import { sliderList, Card } from "../generic"
-import { DEFAULT_POSE } from "../templates"
+import { DEFAULT_POSE } from "../../templates"
 
 class LegPatternPage extends Component {
     pageName = "Leg Patterns"


### PR DESCRIPTION
The `app.js` file is getting to big, it looks like a big `god function` that tries to do almost everything. 

Move the responsibility of updating the parameters in the respective pages and just pass the final 
app state properties and `hexapod` to the app which would then update its the states and the `plot` . 


In addition, I also renamed `this.state.hexapod` to `this.state.hexapodParams` as `hexapod` is also used as the name of an instance of `VirtualHexapod`. I did this to avoid confusion. 

We also pass a hash on the `params` prop of each page, with the key referring to what it actually is. ie instage of `params = this.pose`, we now pass `params = { pose: this.pose}` . inside the component we can access `const pose = this.props.params.pose` when previously we do `const pose = this.props.params`. 

