### PR TITLE
Refactor: Move responsibility down from app to respective pages

### DIFF
--- a/src/components/DimensionsWidget.js
+++ b/src/components/DimensionsWidget.js
@@ -1,9 +1,10 @@
 import React, { Component } from "react"
 import InputField from "./generic/InputField"
 import { Card } from "./generic/SmallWidgets"
+import { DEFAULT_DIMENSIONS } from "../templates"
 
-const ResetButton = ({reset, children }) => (
-    <button type="button" class="button" onClick={reset}>
+const BasicButton = ({ handleClick, children }) => (
+    <button type="button" className="button" onClick={handleClick}>
         {children}
     </button>
 )
@@ -12,20 +13,26 @@ class DimensionsWidget extends Component {
     resetLabel = "Reset"
 
     reset = () => {
-        this.props.onReset("Dimensions")
+        const dimensions = DEFAULT_DIMENSIONS
+        this.props.onUpdate(dimensions)
+    }
+
+    updateDimensions = (name, value) => {
+        const dimensions = { ...this.props.params.dimensions, [name]: value }
+        this.props.onUpdate(dimensions)
     }
 
     updateFieldState = (name, value) => {
-        this.props.onUpdate(name, Math.round(value))
+        this.updateDimensions(name, Math.round(value))
     }
 
     inputFields = () =>
-        Object.keys(this.props.dimensions).map(name => (
+        Object.keys(this.props.params.dimensions).map(name => (
             <InputField
                 key={name}
                 name={name}
                 params={[0, Infinity, 1]}
-                value={this.props.dimensions[name]}
+                value={this.props.params.dimensions[name]}
                 handleChange={this.updateFieldState}
             />
         ))
@@ -33,9 +40,9 @@ class DimensionsWidget extends Component {
     render = () => (
         <Card title="Dimensions" h="h2">
             <div className="row-container flex-wrap">{this.inputFields()}</div>
-            <ResetButton reset={this.reset} widgetName="dimensions">
+            <BasicButton handleClick={this.reset} widgetName="dimensions">
                 {this.resetLabel}
-            </ResetButton>
+            </BasicButton>
         </Card>
     )
 }

--- a/src/components/pages/ForwardKinematicsPage.js
+++ b/src/components/pages/ForwardKinematicsPage.js
@@ -28,6 +28,15 @@ class ForwardKinematicsPage extends Component {
 
     state = { modeBool: false, widgetType: "InputField" }
 
+    updatePose = (name, angle, value) => {
+        const pose = this.props.params.pose
+        const newPose = {
+            ...pose,
+            [name]: { ...pose[name], [angle]: value },
+        }
+        this.props.onUpdate(newPose)
+    }
+
     componentDidMount() {
         this.props.onMount(this.pageName)
     }
@@ -44,8 +53,8 @@ class ForwardKinematicsPage extends Component {
         <LegPoseWidget
             key={name}
             name={name}
-            pose={this.props.params[name]}
-            onUpdate={this.props.onUpdate}
+            pose={this.props.params.pose[name]}
+            onUpdate={this.updatePose}
             WidgetType={this.widgetTypes[this.state.widgetType]}
             renderStacked={this.state.modeBool}
         />

--- a/src/components/pages/InverseKinematicsPage.js
+++ b/src/components/pages/InverseKinematicsPage.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import { sliderList, Card } from "../generic"
+import { solveInverseKinematics } from "../../hexapod"
 
 class InverseKinematicsPage extends Component {
     pageName = "Inverse Kinematics"
@@ -8,13 +9,57 @@ class InverseKinematicsPage extends Component {
         this.props.onMount(this.pageName)
     }
 
+    updateIkParams = (name, value) => {
+        const ikParams = { ...this.props.params.ikParams, [name]: value }
+
+        const result = solveInverseKinematics(this.props.params.dimensions, ikParams)
+
+        if (!result.obtainedSolution) {
+            const updatedStateParams = {
+                ikParams,
+                showPoseMessage: false,
+                showInfo: true,
+                info: { ...result.message, isAlert: true },
+            }
+
+            this.props.onUpdate(null, updatedStateParams)
+            return
+        }
+
+        const updatedStateParams = {
+            ikParams,
+            showPoseMessage: true,
+            showInfo: false,
+            info: { ...result.message, isAlert: false },
+        }
+
+        this.props.onUpdate(result.hexapod, updatedStateParams)
+    }
+
     render() {
-        const translateSliders = sliderList(["tx", "ty", "tz"], [-1, 1, 0.01], this.props)
+        const {
+            rx,
+            ry,
+            rz,
+            tx,
+            ty,
+            tz,
+            hipStance,
+            legStance,
+        } = this.props.params.ikParams
+
+        const translateSliders = sliderList(["tx", "ty", "tz"], [-1, 1, 0.01], {
+            onUpdate: this.updateIkParams,
+            params: { tx, ty, tz },
+        })
 
         const rotateSliders = sliderList(
             ["rx", "ry", "rz", "hipStance", "legStance"],
             [-45, 45, 0.01],
-            this.props
+            {
+                onUpdate: this.updateIkParams,
+                params: { rx, ry, rz, hipStance, legStance },
+            }
         )
 
         return (

--- a/src/components/pages/LegPatternPage.js
+++ b/src/components/pages/LegPatternPage.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import { sliderList, Card } from "../generic"
+import { DEFAULT_POSE } from "../../templates"
 
 class LegPatternPage extends Component {
     pageName = "Leg Patterns"
@@ -8,8 +9,24 @@ class LegPatternPage extends Component {
         this.props.onMount(this.pageName)
     }
 
+    updatePatternPose = (name, value) => {
+        const { alpha, beta, gamma } = this.props.params.patternParams
+        const patternParams = { alpha, beta, gamma, [name]: Number(value) }
+
+        let newPose = {}
+
+        for (const leg in DEFAULT_POSE) {
+            newPose[leg] = patternParams
+        }
+
+        this.props.onUpdate(newPose, patternParams)
+    }
+
     rotateSliders = () =>
-        sliderList(["alpha", "beta", "gamma"], [-180, 180, 1], this.props)
+        sliderList(["alpha", "beta", "gamma"], [-180, 180, 1], {
+            onUpdate: this.updatePatternPose,
+            params: this.props.params.patternParams,
+        })
 
     render = () => (
         <Card title={this.pageName} h="h2">


### PR DESCRIPTION
* Move pose update inside fk page from app
* Move update Pattern to LegPattern page
* Move reset to dimension widget component
* Move ik update to ik page
* Rename hexapod to hexapodParams
    * The hexapod name is loaded, it means an instance of virtual hexapod.
* api-breaking: Make params option a hash for pages
    * Instead of generic prop "params" we can easily see what this props param actually is.

fixes:
  *  Fix ocassional improper value conversion
     Class should be className