### PR TITLE
https://github.com/mithi/hexapod/issues/36 resolved

### DIFF
--- a/src/components/generic/NumberInputField.js
+++ b/src/components/generic/NumberInputField.js
@@ -19,7 +19,7 @@ class InputField extends Component {
     }
 
     handleChange(value) {
-        const [minValue, maxValue, stepValue] = this.props.params
+        const [minValue, maxValue, stepValue] = this.props.attributes
         const validity = this.myRef.current.validity
 
         if (validity.badInput) {
@@ -53,9 +53,9 @@ class InputField extends Component {
     }
 
     render() {
-        const { name, params, id, value } = this.props
+        const { name, attributes, id, value } = this.props
         const newId = id || name
-        const [minValue, maxValue, stepValue] = params
+        const [minValue, maxValue, stepValue] = attributes
 
         return (
             <div className="cell">

--- a/src/components/generic/Slider.js
+++ b/src/components/generic/Slider.js
@@ -11,16 +11,16 @@ import React from "react"
  *   handleChange: callback to call when slider changes
  *
  * */
-const Slider = ({ name, value, params, handleChange }) => (
+const Slider = ({ name, value, attributes, handleChange }) => (
     <div className="slider-container cell">
         <label htmlFor={name} className="label">
             {name}: {value}
         </label>
         <input
             type="range"
-            min={params[0]}
-            max={params[1]}
-            step={params[2]}
+            min={attributes[0]}
+            max={attributes[1]}
+            step={attributes[2]}
             value={value}
             onChange={e => handleChange(name, e.target.value)}
             className="slider"
@@ -45,7 +45,7 @@ const sliderList = (sliderNames, sliderSettings, { onUpdate, params }) =>
         <Slider
             key={name}
             name={name}
-            params={sliderSettings}
+            attributes={sliderSettings}
             handleChange={onUpdate}
             value={params[name]}
         />


### PR DESCRIPTION
In code, `slidersettings` contains the component attributes and pass it to the `<input/>` component so attributes make better fit here rather than using params.