### PR TITLE
Refactor linkage and hexagon classes

### DIFF
--- a/src/hexapod/Hexagon.js
+++ b/src/hexapod/Hexagon.js
@@ -80,24 +80,22 @@ class Hexagon {
     }
 
     cloneTrotShift(transformMatrix, tx, ty, tz) {
-        let clone = new Hexagon(this.dimensions, { hasNoPoints: true })
-        clone.cog = this.cog.cloneTrotShift(transformMatrix, tx, ty, tz)
-        clone.head = this.head.cloneTrotShift(transformMatrix, tx, ty, tz)
-        clone.verticesList = this.verticesList.map(point =>
-            point.cloneTrotShift(transformMatrix, tx, ty, tz)
-        )
-        return clone
+        return this._doTransform("cloneTrotShift", transformMatrix, tx, ty, tz)
     }
 
     cloneTrot(transformMatrix) {
-        return this.cloneTrotShift(transformMatrix, 0, 0, 0)
+        return this._doTransform("cloneTrot", transformMatrix)
     }
 
     cloneShift(tx, ty, tz) {
+        return this._doTransform("cloneShift", tx, ty, tz)
+    }
+
+    _doTransform(transformFunction, ...args) {
         let clone = new Hexagon(this.dimensions, { hasNoPoints: true })
-        clone.cog = this.cog.cloneShift(tx, ty, tz)
-        clone.head = this.head.cloneShift(tx, ty, tz)
-        clone.verticesList = this.verticesList.map(point => point.cloneShift(tx, ty, tz))
+        clone.cog = this.cog[transformFunction](...args)
+        clone.head = this.head[transformFunction](...args)
+        clone.verticesList = this.verticesList.map(point => point[transformFunction](...args))
         return clone
     }
 }

--- a/src/hexapod/Hexagon.js
+++ b/src/hexapod/Hexagon.js
@@ -95,7 +95,9 @@ class Hexagon {
         let clone = new Hexagon(this.dimensions, { hasNoPoints: true })
         clone.cog = this.cog[transformFunction](...args)
         clone.head = this.head[transformFunction](...args)
-        clone.verticesList = this.verticesList.map(point => point[transformFunction](...args))
+        clone.verticesList = this.verticesList.map(point =>
+            point[transformFunction](...args)
+        )
         return clone
     }
 }

--- a/src/hexapod/Linkage.js
+++ b/src/hexapod/Linkage.js
@@ -153,22 +153,20 @@ class Linkage {
      * and again be translated by tx, ty, tz
      * */
     cloneTrotShift(transformMatrix, tx, ty, tz) {
-        const newPointsList = this.allPointsList.map(oldPoint =>
-            oldPoint.cloneTrotShift(transformMatrix, tx, ty, tz)
-        )
-        return this._buildClone(newPointsList)
+        return this._doTransform("cloneTrotShift", transformMatrix, tx, ty, tz)
     }
 
     cloneTrot(transformMatrix) {
-        const newPointsList = this.allPointsList.map(oldPoint =>
-            oldPoint.cloneTrot(transformMatrix)
-        )
-        return this._buildClone(newPointsList)
+        return this._doTransform("cloneTrot", transformMatrix)
     }
 
     cloneShift(tx, ty, tz) {
+        return this._doTransform("cloneShift", tx, ty, tz)
+    }
+
+    _doTransform(transformFunction, ...args) {
         const newPointsList = this.allPointsList.map(oldPoint =>
-            oldPoint.cloneShift(tx, ty, tz)
+            oldPoint[transformFunction](...args)
         )
         return this._buildClone(newPointsList)
     }
@@ -189,14 +187,14 @@ class Linkage {
 
     /* *
      * .............
-     * structure of pointNameIdMap
+     * structure of pointNameIds
      * .............
      *
      * pointNameIds = [
-     *   {name: "{legPosition}-bodyContactPoint", id: "{legId}-0" },
-     *   {name: "{legPosition}-coxiaPoint", id: "{legId}-1" },
-     *   {name: "{legPosition}-femurPoint", id: "{legId}-2" },
-     *   {name: "{legPosition}-footTipPoint", id: "{legId}-3" },
+     *   { name: "{legPosition}-bodyContactPoint", id: "{legId}-0" },
+     *   { name: "{legPosition}-coxiaPoint", id: "{legId}-1" },
+     *   { name: "{legPosition}-femurPoint", id: "{legId}-2" },
+     *   { name: "{legPosition}-footTipPoint", id: "{legId}-3" },
      * ]
      *
      * */

--- a/src/tests/Linkage.test.js
+++ b/src/tests/Linkage.test.js
@@ -14,17 +14,18 @@ test.each(CASES)("Should Initialize Linkage: %p", thisCase => {
         params.pose
     )
 
-    const { pointsMap, allPointsList } = linkage
+    const { allPointsList } = linkage
 
     expect(linkage.id).toBe(POSITION_NAME_TO_ID_MAP[params.position])
     expect(linkage.name).toBe(params.position + "Leg")
-    expect(pointsMap.bodyContactPoint).toBe(allPointsList[0])
-    expect(pointsMap.coxiaPoint).toBe(allPointsList[1])
-    expect(pointsMap.femurPoint).toBe(allPointsList[2])
-    expect(pointsMap.footTipPoint).toBe(allPointsList[3])
 
-    expectToBeEqualPoints(pointsMap.bodyContactPoint, result.bodyContactPoint)
-    expectToBeEqualPoints(pointsMap.coxiaPoint, result.coxiaPoint)
-    expectToBeEqualPoints(pointsMap.femurPoint, result.femurPoint)
-    expectToBeEqualPoints(pointsMap.footTipPoint, result.footTipPoint)
+    expect(linkage.bodyContactPoint).toBe(allPointsList[0])
+    expect(linkage.coxiaPoint).toBe(allPointsList[1])
+    expect(linkage.femurPoint).toBe(allPointsList[2])
+    expect(linkage.footTipPoint).toBe(allPointsList[3])
+
+    expectToBeEqualPoints(linkage.bodyContactPoint, result.bodyContactPoint)
+    expectToBeEqualPoints(linkage.coxiaPoint, result.coxiaPoint)
+    expectToBeEqualPoints(linkage.femurPoint, result.femurPoint)
+    expectToBeEqualPoints(linkage.footTipPoint, result.footTipPoint)
 })


### PR DESCRIPTION
# For `Linkage`
pointsMap hash no longer exists.pointsMap just complicates internal computations.
It has been replaced by a list of 4 points instead (allPointsList)

# For both `Hexagon` and `Linkage`
`send` the function to use  to  `this._doTransform` method and transform all points of that object given the function specified. This removes the duplication present currently. 