### PR TITLE
style/switch labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "react-icons": "^3.10.0",
         "react-markdown": "^4.3.1",
         "react-plotly.js": "^2.4.0",
-        "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "3.4.1",
         "source-map-explorer": "^2.4.2"

--- a/src/components/DimensionsWidget.js
+++ b/src/components/DimensionsWidget.js
@@ -38,6 +38,7 @@ class DimensionsWidget extends Component {
     get toggleSwitch() {
         return (
             <ToggleSwitch
+                id="DimensionsWidgetSwitch"
                 value={this.state.toggleLabel}
                 handleChange={this.toggleMode}
                 showLabel={true}

--- a/src/components/generic/SmallWidgets.js
+++ b/src/components/generic/SmallWidgets.js
@@ -11,18 +11,21 @@ const AlertBox = ({ info }) => (
     </div>
 )
 
-const ToggleSwitch = ({ value, handleChange, showLabel, labelTop }) => (
+const ToggleSwitch = ({ id, value, handleChange, showLabel, labelTop }) => (
     <div className="switch-container">
         {
             // prettier-ignore
-            showLabel && labelTop ? (<label className="label">{value}<br /></label>) : null
+            showLabel && labelTop ? (<label className="label">{value}</label>) : null
         }
-        <label className="switch">
-            <input type="checkbox" value={value} onChange={handleChange} />
+        <label className="switch" htmlFor={id}>
+            <input id={id} type="checkbox" value={value} onChange={handleChange} />
             <span className="toggle-switch-widget round"></span>
-            <br />
-            {showLabel && !labelTop ? <label className="label">{value}</label> : null}
         </label>
+        {showLabel && !labelTop ? (
+            <label className="label" htmlFor={id}>
+                {value}
+            </label>
+        ) : null}
     </div>
 )
 

--- a/src/components/pages/ForwardKinematicsPage.js
+++ b/src/components/pages/ForwardKinematicsPage.js
@@ -59,6 +59,7 @@ class ForwardKinematicsPage extends Component {
     get toggleSwitch() {
         return (
             <ToggleSwitch
+                id="FwdKinematicsSwitch"
                 value={this.state.widgetType}
                 handleChange={this.toggleMode}
                 showLabel={false}

--- a/src/index.css
+++ b/src/index.css
@@ -304,9 +304,9 @@ input[type="number"] {
 }
 
 .switch-container {
+    cursor: pointer;
     display: flex;
-    flex-direction: column;
-    justify-content: center;
+    align-items: center;
     margin-left: 5px;
 }
 
@@ -317,6 +317,10 @@ input[type="number"] {
     width: 30px;
     height: 17px;
     border: 1px rgb(46, 204, 113);
+}
+
+.switch + .label {
+    cursor: pointer;
 }
 
 /* Hide default HTML checkbox */

--- a/src/tests/components/__snapshots__/DimensionWidget.test.js.snap
+++ b/src/tests/components/__snapshots__/DimensionWidget.test.js.snap
@@ -15,20 +15,22 @@ exports[`Dimension Widget renders component correctly 1`] = `
         >
           <label
             class="switch"
+            for="DimensionsWidgetSwitch"
           >
             <input
+              id="DimensionsWidgetSwitch"
               type="checkbox"
               value="1x"
             />
             <span
               class="toggle-switch-widget round"
             />
-            <br />
-            <label
-              class="label"
-            >
-              1x
-            </label>
+          </label>
+          <label
+            class="label"
+            for="DimensionsWidgetSwitch"
+          >
+            1x
           </label>
         </div>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8945,7 +8945,7 @@ react-router-dom@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@5.2.0, react-router@^5.2.0:
+react-router@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
   integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==


### PR DESCRIPTION
This one might not be wanted, but the x1/x5 indicators seemed a bit off, this PR places them to the right of the switch.

Also, this PR removes `react-router` as it is already installed by `react-router-dom` (run `yarn why react-router` and you'll see)

