### PR TITLE
refactor: Move some app state down to children 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
-    
+
     - uses: actions/cache@v2
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
@@ -39,10 +39,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node }}
-    
+
      # Yarn is included in the list of software installed on the GitHub-hosted Ubuntu
      # so there's no need to include a step install Yarn.
- 
+
     - name: Add prettier
       run: yarn add prettier --dev
 
@@ -50,12 +50,12 @@ jobs:
       run: yarn run prettier --config ./.prettierrc.yaml --check  ./src/*
 
     - name: Install project dependencies
-      if: steps.yarn-cache.outputs.cache-hit != 'true' # Over here!
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: yarn
 
     - name: Build project
-      run: yarn build         
-    
+      run: yarn build
+
     - name: Test and generate coverage report
       run: yarn test --watchAll=false --coverage
 
@@ -63,3 +63,4 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         name: codecov-umbrella
+        fail_ci_if_error: false

--- a/src/App.js
+++ b/src/App.js
@@ -33,9 +33,6 @@ class App extends React.Component {
         showInfo: false,
         info: {},
 
-        ikParams: defaults.DEFAULT_IK_PARAMS,
-        patternParams: defaults.DEFAULT_PATTERN_PARAMS,
-
         hexapodParams: {
             dimensions: defaults.DEFAULT_DIMENSIONS,
             pose: defaults.DEFAULT_POSE,
@@ -55,10 +52,10 @@ class App extends React.Component {
 
     onPageLoad = pageName => {
         ReactGA.pageview(window.location.pathname + window.location.search)
+        this.setState({ currentPage: pageName })
 
         if (pageName === SECTION_NAMES.landingPage) {
             this.setState({
-                currentPage: pageName,
                 inHexapodPage: false,
                 showInfo: false,
                 showPoseMessage: false,
@@ -67,14 +64,12 @@ class App extends React.Component {
         }
 
         this.setState({
-            currentPage: pageName,
             inHexapodPage: true,
             showInfo: false,
             showPoseMessage: false,
-            ikParams: defaults.DEFAULT_IK_PARAMS,
-            patternParams: defaults.DEFAULT_PATTERN_PARAMS,
             hexapodParams: { ...this.state.hexapodParams, pose: defaults.DEFAULT_POSE },
         })
+
         this.updatePlot(this.state.hexapodParams.dimensions, defaults.DEFAULT_POSE)
     }
 
@@ -117,7 +112,7 @@ class App extends React.Component {
      * Handle individual input fields update
      * * * * * * * * * * * * * */
 
-    updateIkParams = (hexapod, updatedStateParams) => {
+    updateIk = (hexapod, updatedStateParams) => {
         this.updatePlotWithHexapod(hexapod)
         this.setState({ ...updatedStateParams })
     }
@@ -126,11 +121,6 @@ class App extends React.Component {
         this.updatePlot(dimensions, this.state.hexapodParams.pose)
 
     updatePose = pose => this.updatePlot(this.state.hexapodParams.dimensions, pose)
-
-    updatePatternPose = (pose, patternParams) => {
-        this.updatePlot(this.state.hexapodParams.dimensions, pose)
-        this.setState({ patternParams })
-    }
 
     /* * * * * * * * * * * * * *
      * Control display of widgets
@@ -189,18 +179,13 @@ class App extends React.Component {
                 <InverseKinematicsPage
                     params={{
                         dimensions: this.state.hexapodParams.dimensions,
-                        ikParams: this.state.ikParams,
                     }}
-                    onUpdate={this.updateIkParams}
+                    onUpdate={this.updateIk}
                     onMount={this.onPageLoad}
                 />
             </Route>
             <Route path={PATHS.legPatterns.path}>
-                <LegPatternPage
-                    params={{ patternParams: this.state.patternParams }}
-                    onUpdate={this.updatePatternPose}
-                    onMount={this.onPageLoad}
-                />
+                <LegPatternPage onUpdate={this.updatePose} onMount={this.onPageLoad} />
             </Route>
         </Switch>
     )

--- a/src/components/pages/InverseKinematicsPage.js
+++ b/src/components/pages/InverseKinematicsPage.js
@@ -1,18 +1,16 @@
 import React, { Component } from "react"
 import { sliderList, Card, BasicButton } from "../generic"
 import { solveInverseKinematics } from "../../hexapod"
-import { DEFAULT_IK_PARAMS } from "../../templates"
 import { SECTION_NAMES, IK_SLIDERS_LABELS, RESET_LABEL } from "../vars"
+import { DEFAULT_IK_PARAMS } from "../../templates"
 
-const _updatedStateParamsUnsolved = (ikParams, message) => ({
-    ikParams,
+const _updatedStateParamsUnsolved = message => ({
     showPoseMessage: false,
     showInfo: true,
     info: { ...message, isAlert: true },
 })
 
-const _updatedStateParamsSolved = (ikParams, message) => ({
-    ikParams,
+const _updatedStateParamsSolved = message => ({
     showPoseMessage: true,
     showInfo: false,
     info: { ...message, isAlert: false },
@@ -20,37 +18,42 @@ const _updatedStateParamsSolved = (ikParams, message) => ({
 
 class InverseKinematicsPage extends Component {
     pageName = SECTION_NAMES.inverseKinematics
+    state = { ikParams: DEFAULT_IK_PARAMS }
 
     componentDidMount() {
         this.props.onMount(this.pageName)
     }
 
     updateIkParams = (name, value) => {
-        const ikParams = { ...this.props.params.ikParams, [name]: value }
+        const ikParams = { ...this.state.ikParams, [name]: value }
+        this.setState({ ikParams })
+
         const result = solveInverseKinematics(this.props.params.dimensions, ikParams)
 
         if (!result.obtainedSolution) {
-            const stateParams = _updatedStateParamsUnsolved(ikParams, result.message)
+            const stateParams = _updatedStateParamsUnsolved(result.message)
             this.props.onUpdate(null, stateParams)
             return
         }
 
-        const stateParams = _updatedStateParamsSolved(ikParams, result.message)
+        const stateParams = _updatedStateParamsSolved(result.message)
         this.props.onUpdate(result.hexapod, stateParams)
     }
 
     reset = () => {
-        const dimensions = this.props.params.dimensions
-        const result = solveInverseKinematics(dimensions, DEFAULT_IK_PARAMS)
-
-        const stateParams = _updatedStateParamsSolved(DEFAULT_IK_PARAMS, result.message)
+        this.setState({ DEFAULT_IK_PARAMS })
+        const result = solveInverseKinematics(
+            this.props.params.dimensions,
+            DEFAULT_IK_PARAMS
+        )
+        const stateParams = _updatedStateParamsSolved(result.message)
         this.props.onUpdate(result.hexapod, stateParams)
     }
 
     get sliders() {
         return sliderList({
             names: IK_SLIDERS_LABELS,
-            values: this.props.params.ikParams,
+            values: this.state.ikParams,
             handleChange: this.updateIkParams,
         })
     }

--- a/src/components/pages/LegPatternPage.js
+++ b/src/components/pages/LegPatternPage.js
@@ -5,32 +5,34 @@ import { SECTION_NAMES, ANGLE_NAMES, RESET_LABEL } from "../vars"
 
 class LegPatternPage extends Component {
     pageName = SECTION_NAMES.legPatterns
+    state = { patternParams: DEFAULT_PATTERN_PARAMS }
 
     componentDidMount() {
         this.props.onMount(this.pageName)
+        this.setState({ patternParams: DEFAULT_PATTERN_PARAMS })
     }
 
     updatePatternPose = (name, value) => {
-        const { alpha, beta, gamma } = this.props.params.patternParams
-        const patternParams = { alpha, beta, gamma, [name]: Number(value) }
-
+        const patternParams = { ...this.state.patternParams, [name]: Number(value) }
         let newPose = {}
 
         for (const leg in DEFAULT_POSE) {
             newPose[leg] = patternParams
         }
 
-        this.props.onUpdate(newPose, patternParams)
+        this.props.onUpdate(newPose)
+        this.setState({ patternParams })
     }
 
     reset = () => {
-        this.props.onUpdate(DEFAULT_POSE, DEFAULT_PATTERN_PARAMS)
+        this.props.onUpdate(DEFAULT_POSE)
+        this.setState({ patternParams: DEFAULT_PATTERN_PARAMS })
     }
 
     get sliders() {
         return sliderList({
             names: ANGLE_NAMES,
-            values: this.props.params.patternParams,
+            values: this.state.patternParams,
             handleChange: this.updatePatternPose,
         })
     }


### PR DESCRIPTION
App component doesn't directly use `ikParams` and `patternParams` so it makes sense to move these states to the corresponding page component where the those widgets are. 