### PR TITLE
refactor, breaking: Move pose table and alert box to IK page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,14 +4,7 @@ import ReactGA from "react-ga"
 import { VirtualHexapod, getNewPlotParams } from "./hexapod"
 import * as defaults from "./templates"
 import { SECTION_NAMES, PATHS } from "./components/vars"
-import {
-    PoseTable,
-    Nav,
-    NavDetailed,
-    HexapodPlot,
-    DimensionsWidget,
-    AlertBox,
-} from "./components"
+import { Nav, NavDetailed, HexapodPlot, DimensionsWidget } from "./components"
 import {
     ForwardKinematicsPage,
     InverseKinematicsPage,
@@ -30,9 +23,6 @@ class App extends React.Component {
     state = {
         currentPage: SECTION_NAMES.LandingPage,
         inHexapodPage: false,
-        showPoseMessage: true,
-        showInfo: false,
-        info: {},
 
         hexapodParams: {
             dimensions: defaults.DEFAULT_DIMENSIONS,
@@ -56,18 +46,12 @@ class App extends React.Component {
         this.setState({ currentPage: pageName })
 
         if (pageName === SECTION_NAMES.landingPage) {
-            this.setState({
-                inHexapodPage: false,
-                showInfo: false,
-                showPoseMessage: false,
-            })
+            this.setState({ inHexapodPage: false })
             return
         }
 
         this.setState({
             inHexapodPage: true,
-            showInfo: false,
-            showPoseMessage: false,
             hexapodParams: { ...this.state.hexapodParams, pose: defaults.DEFAULT_POSE },
         })
 
@@ -77,11 +61,6 @@ class App extends React.Component {
     /* * * * * * * * * * * * * *
      * Handle plot update
      * * * * * * * * * * * * * */
-
-    updatePlot = (dimensions, pose) => {
-        const newHexapodModel = new VirtualHexapod(dimensions, pose)
-        this.updatePlotWithHexapod(newHexapodModel)
-    }
 
     updatePlotWithHexapod = hexapod => {
         if (hexapod === null || hexapod === undefined || !hexapod.foundSolution) {
@@ -109,13 +88,9 @@ class App extends React.Component {
         this.setState({ ...this.state, plot: plot })
     }
 
-    /* * * * * * * * * * * * * *
-     * Handle individual input fields update
-     * * * * * * * * * * * * * */
-
-    updateIk = (hexapod, updatedStateParams) => {
-        this.updatePlotWithHexapod(hexapod)
-        this.setState({ ...updatedStateParams })
+    updatePlot = (dimensions, pose) => {
+        const newHexapodModel = new VirtualHexapod(dimensions, pose)
+        this.updatePlotWithHexapod(newHexapodModel)
     }
 
     updateDimensions = dimensions =>
@@ -127,16 +102,7 @@ class App extends React.Component {
      * Control display of widgets
      * * * * * * * * * * * * * */
 
-    mightShowMessage = () =>
-        this.state.showInfo ? <AlertBox info={this.state.info} /> : null
-
     mightShowDetailedNav = () => (this.state.inHexapodPage ? <NavDetailed /> : null)
-
-    mightShowPoseTable = () => {
-        if (this.state.showPoseMessage) {
-            return <PoseTable pose={this.state.hexapodParams.pose} />
-        }
-    }
 
     mightShowDimensions = () => {
         if (this.state.inHexapodPage) {
@@ -181,7 +147,7 @@ class App extends React.Component {
                     params={{
                         dimensions: this.state.hexapodParams.dimensions,
                     }}
-                    onUpdate={this.updateIk}
+                    onUpdate={this.updatePlotWithHexapod}
                     onMount={this.onPageLoad}
                 />
             </Route>
@@ -211,8 +177,6 @@ class App extends React.Component {
                 <div className="sidebar column-container cell">
                     {this.mightShowDimensions()}
                     {this.showPage()}
-                    {this.mightShowPoseTable()}
-                    {this.mightShowMessage()}
                 </div>
                 {this.mightShowPlot()}
             </div>

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,15 +1,15 @@
 import React from "react"
-import { URL_LINKS, PATH_LINKS, ICON_COMPONENTS } from "./vars"
+import { URL_LINKS, PATH_LINKS } from "./vars"
 import { Link } from "react-router-dom"
 
 const NAV_BULLETS_PREFIX = "navBullet"
 const NAV_DETAILED_PREFIX = "navDetailed"
 
-const BulletPageLink = ({ path, description }) => (
+const BulletPageLink = ({ link, showDesc }) => (
     <li>
-        <Link to={path} className="link-icon">
+        <Link to={link.path} className="link-icon">
             <span>
-                {ICON_COMPONENTS.circle} {description}
+                {link.icon} {showDesc ? link.description : null}
             </span>
         </Link>
     </li>
@@ -42,7 +42,7 @@ const NavBullets = () => (
         ))}
 
         {PATH_LINKS.map(link => (
-            <BulletPageLink key={NAV_BULLETS_PREFIX + link.path} path={link.path} />
+            <BulletPageLink key={NAV_BULLETS_PREFIX + link.path} link={link} />
         ))}
     </ul>
 )
@@ -63,8 +63,8 @@ const NavDetailed = () => (
                 {PATH_LINKS.map(link => (
                     <BulletPageLink
                         key={NAV_DETAILED_PREFIX + link.path}
-                        path={link.path}
-                        description={link.description}
+                        link={link}
+                        showDesc={true}
                     />
                 ))}
             </ul>

--- a/src/components/pages/InverseKinematicsPage.js
+++ b/src/components/pages/InverseKinematicsPage.js
@@ -1,24 +1,13 @@
 import React, { Component } from "react"
-import { sliderList, Card, BasicButton } from "../generic"
+import { sliderList, Card, BasicButton, AlertBox } from "../generic"
 import { solveInverseKinematics } from "../../hexapod"
 import { SECTION_NAMES, IK_SLIDERS_LABELS, RESET_LABEL } from "../vars"
 import { DEFAULT_IK_PARAMS } from "../../templates"
-
-const _updatedStateParamsUnsolved = message => ({
-    showPoseMessage: false,
-    showInfo: true,
-    info: { ...message, isAlert: true },
-})
-
-const _updatedStateParamsSolved = message => ({
-    showPoseMessage: true,
-    showInfo: false,
-    info: { ...message, isAlert: false },
-})
+import { PoseTable } from ".."
 
 class InverseKinematicsPage extends Component {
     pageName = SECTION_NAMES.inverseKinematics
-    state = { ikParams: DEFAULT_IK_PARAMS }
+    state = { ikParams: DEFAULT_IK_PARAMS, errorMessage: null }
 
     componentDidMount() {
         this.props.onMount(this.pageName)
@@ -26,28 +15,33 @@ class InverseKinematicsPage extends Component {
 
     updateIkParams = (name, value) => {
         const ikParams = { ...this.state.ikParams, [name]: value }
-        this.setState({ ikParams })
-
         const result = solveInverseKinematics(this.props.params.dimensions, ikParams)
 
         if (!result.obtainedSolution) {
-            const stateParams = _updatedStateParamsUnsolved(result.message)
-            this.props.onUpdate(null, stateParams)
+            this.props.onUpdate(null)
+            this.setState({ errorMessage: result.message, pose: null })
             return
         }
 
-        const stateParams = _updatedStateParamsSolved(result.message)
-        this.props.onUpdate(result.hexapod, stateParams)
+        this.update(result.hexapod, ikParams)
     }
 
     reset = () => {
-        this.setState({ ikParams: DEFAULT_IK_PARAMS })
         const result = solveInverseKinematics(
             this.props.params.dimensions,
             DEFAULT_IK_PARAMS
         )
-        const stateParams = _updatedStateParamsSolved(result.message)
-        this.props.onUpdate(result.hexapod, stateParams)
+        this.update(result.hexapod, DEFAULT_IK_PARAMS)
+    }
+
+    update = (hexapod, ikParams) => {
+        this.setState({
+            ikParams: ikParams,
+            errorMessage: null,
+            pose: hexapod.pose,
+        })
+
+        this.props.onUpdate(hexapod)
     }
 
     get sliders() {
@@ -58,15 +52,28 @@ class InverseKinematicsPage extends Component {
         })
     }
 
+    get additionalInfo() {
+        // happens when component is not yet mounted but rendered
+        if (this.state.pose === undefined) {
+            return null
+        }
+
+        if (this.state.errorMessage === null) {
+            return <PoseTable pose={this.state.pose} />
+        } else {
+            return <AlertBox info={this.state.errorMessage} />
+        }
+    }
+
     render() {
         const sliders = this.sliders
-
         return (
             <Card title={this.pageName} h="h2">
                 <div className="row-container">{sliders.slice(0, 3)}</div>
                 <div className="row-container">{sliders.slice(3, 6)}</div>
                 <div className="row-container">{sliders.slice(6, 8)}</div>
                 <BasicButton handleClick={this.reset}>{RESET_LABEL}</BasicButton>
+                {this.additionalInfo}
             </Card>
         )
     }

--- a/src/components/pages/InverseKinematicsPage.js
+++ b/src/components/pages/InverseKinematicsPage.js
@@ -2,12 +2,12 @@ import React, { Component } from "react"
 import { sliderList, Card, BasicButton, AlertBox } from "../generic"
 import { solveInverseKinematics } from "../../hexapod"
 import { SECTION_NAMES, IK_SLIDERS_LABELS, RESET_LABEL } from "../vars"
-import { DEFAULT_IK_PARAMS } from "../../templates"
+import { DEFAULT_IK_PARAMS, DEFAULT_POSE } from "../../templates"
 import { PoseTable } from ".."
 
 class InverseKinematicsPage extends Component {
     pageName = SECTION_NAMES.inverseKinematics
-    state = { ikParams: DEFAULT_IK_PARAMS, errorMessage: null }
+    state = { ikParams: DEFAULT_IK_PARAMS, errorMessage: null, pose: DEFAULT_POSE }
 
     componentDidMount() {
         this.props.onMount(this.pageName)
@@ -53,11 +53,6 @@ class InverseKinematicsPage extends Component {
     }
 
     get additionalInfo() {
-        // happens when component is not yet mounted but rendered
-        if (this.state.pose === undefined) {
-            return null
-        }
-
         if (this.state.errorMessage === null) {
             return <PoseTable pose={this.state.pose} />
         } else {

--- a/src/components/vars.js
+++ b/src/components/vars.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { GiCoffeeMug } from "react-icons/gi"
-import { FaGithubAlt, FaTimes, FaCheck } from "react-icons/fa"
+import { FaGithubAlt, FaTimes, FaCheck, FaHome, FaSquare } from "react-icons/fa"
 import { GrStatusGoodSmall } from "react-icons/gr"
 
 const SECTION_NAMES = {
@@ -71,9 +71,11 @@ const RANGE_PARAMS = {
 const ICON_COMPONENTS = {
     mug: <GiCoffeeMug className="vertical-align" />,
     circle: <GrStatusGoodSmall className="small-icon" />,
+    square: <FaSquare className="small-icon" />,
     octocat: <FaGithubAlt className="vertical-align" />,
     check: <FaCheck className="vertical-align" />,
     times: <FaTimes className="vertical-align" />,
+    home: <FaHome className="vertical-align" />,
 }
 
 /*************
@@ -84,23 +86,28 @@ const PATHS = {
     inverseKinematics: {
         path: PATH_NAMES.inverseKinematics,
         description: SECTION_NAMES.inverseKinematics,
+        icon: ICON_COMPONENTS.circle,
     },
     forwardKinematics: {
         path: PATH_NAMES.forwardKinematics,
         description: SECTION_NAMES.forwardKinematics,
+        icon: ICON_COMPONENTS.circle,
     },
     legPatterns: {
         path: PATH_NAMES.legPatterns,
         description: SECTION_NAMES.legPatterns,
+        icon: ICON_COMPONENTS.circle,
     },
     landingPage: {
         path: PATH_NAMES.landingPage,
         description: SECTION_NAMES.landingPage,
+        icon: ICON_COMPONENTS.home,
     },
 
     walkingGaits: {
         path: PATH_NAMES.walkingGaits,
         description: SECTION_NAMES.walkingGaits,
+        icon: ICON_COMPONENTS.circle,
     },
 }
 


### PR DESCRIPTION
AlertBox and PoseTable components are currently residing on the App Component. 
The IK page component  informs the App how AlertBox and PoseTable are handled.
This seems to be bad practice and adds unnecessary complications to the code. 

This PR simplifies things. The App component no longer manages AlertBox and PoseTable,
this responsibility is moved down to the IK page component.